### PR TITLE
Enforce a limit of 1 MiB for quotes to prevent DoS

### DIFF
--- a/verification/types/quote.go
+++ b/verification/types/quote.go
@@ -123,8 +123,10 @@ type SGXQuote4 struct {
 // ParseQuote parses an Intel TDX v4 Quote. The expected input is the complete quote.
 func ParseQuote(rawQuote []byte) (SGXQuote4, error) {
 	quoteLength := len(rawQuote)
-	if len(rawQuote) <= 636 {
+	if quoteLength <= 636 {
 		return SGXQuote4{}, fmt.Errorf("quote structure is too short to be parsed (received: %d bytes)", quoteLength)
+	} else if quoteLength > 1048576 {
+		return SGXQuote4{}, fmt.Errorf("quote is too large (over 1 MiB, received: %d bytes)", quoteLength)
 	}
 
 	quoteHeader := SGXQuote4Header{
@@ -350,6 +352,7 @@ func parseQEReportInnerCertificationData(qeReportAuthDataCertData []byte) (Certi
 	if qeReportAuthDataCertDataLength <= 6 {
 		return CertificationData{}, fmt.Errorf("QEReportCertificationData.CertificationData is too short to be parsed (received: %d bytes)", qeReportAuthDataCertDataLength)
 	}
+
 	qeAuthDataInnerCertData := CertificationData{
 		Type:           binary.LittleEndian.Uint16(qeReportAuthDataCertData[0:2]),
 		ParsedDataSize: binary.LittleEndian.Uint32(qeReportAuthDataCertData[2:6]),

--- a/verification/types/quote_test.go
+++ b/verification/types/quote_test.go
@@ -63,6 +63,8 @@ func FuzzParseQuote(f *testing.F) {
 func FuzzParseSignature(f *testing.F) {
 	f.Fuzz(func(t *testing.T, a []byte) {
 		assert := assert.New(t)
+		// Note: Might be susceptible to large memory allocations (> 4 GiB).
+		// Length is limited by caller (ParseQuote), not here since it's private.
 		assert.NotPanics(func() { _, _ = parseSignature(a) })
 	})
 }
@@ -70,6 +72,8 @@ func FuzzParseSignature(f *testing.F) {
 func FuzzParseQEReportCertificationData(f *testing.F) {
 	f.Fuzz(func(t *testing.T, a []byte) {
 		assert := assert.New(t)
+		// Note: Might be susceptible to large memory allocations (> 4 GiB).
+		// Length is limited by caller (ParseQuote), not here since it's private.
 		assert.NotPanics(func() { _, _ = parseQEReportCertificationData(a) })
 	})
 }
@@ -77,6 +81,8 @@ func FuzzParseQEReportCertificationData(f *testing.F) {
 func FuzzParseQEReportInnerCertificationData(f *testing.F) {
 	f.Fuzz(func(t *testing.T, a []byte) {
 		assert := assert.New(t)
+		// Note: Might be susceptible to large memory allocations (> 4 GiB).
+		// Length is limited by caller (ParseQuote), not here since it's private.
 		assert.NotPanics(func() { _, _ = parseQEReportInnerCertificationData(a) })
 	})
 }


### PR DESCRIPTION
See title.

I didn't implement this in the private child functions, given that they should only be really called from ParseQuote.
I could also implement them there but generally this seems a bit pointless. Only seems to be useful for the Fuzz tests, or if we indeed plan to use these functions later in some way or another.

If you think it makes sense to double check, I can also add it there. But it seemed pointless to me since ParseQuote limits the passed slice to be 1 MiB, and any sub-slices cannot be larger than this anyway (plus out-of-bounds is already checked).