### PR TITLE
Dont return error on creating PCS client

### DIFF
--- a/testing/pcs/main.go
+++ b/testing/pcs/main.go
@@ -16,10 +16,7 @@ func main() {
 }
 
 func pcsConnection() error {
-	client, err := pcs.New()
-	if err != nil {
-		return err
-	}
+	client := pcs.New()
 
 	crl, intermediateCert, err := client.GetPCKCRL(context.Background(), pcs.TDXPlatform)
 	if err != nil {

--- a/testing/verify/main.go
+++ b/testing/verify/main.go
@@ -16,10 +16,7 @@ func main() {
 }
 
 func testVerify() error {
-	verifier, err := verification.New()
-	if err != nil {
-		return err
-	}
+	verifier := verification.New()
 
 	quote, err := os.ReadFile("./blobs/quote")
 	if err != nil {

--- a/verification/crypto/crypto.go
+++ b/verification/crypto/crypto.go
@@ -45,3 +45,17 @@ func ParsePEMCertificateChain(certChainPEM []byte) ([]*x509.Certificate, error) 
 	}
 	return signingChain, nil
 }
+
+// MustParsePEMCertificate parses a single certificate from a PEM-encoded byte slice.
+// If multiple certificates are present, only the first one is returned.
+// It panics if the certificate is invalid or the PEM data contains no certificates.
+func MustParsePEMCertificate(certPEM []byte) *x509.Certificate {
+	certs, err := ParsePEMCertificateChain(certPEM)
+	if err != nil {
+		panic(err)
+	}
+	if len(certs) == 0 {
+		panic("expected at least one certificate")
+	}
+	return certs[0]
+}

--- a/verification/pcs/pcs.go
+++ b/verification/pcs/pcs.go
@@ -43,7 +43,6 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -108,19 +107,13 @@ type TrustedServicesClient struct {
 }
 
 // New returns a new TrustedServicesClient.
-func New() (*TrustedServicesClient, error) {
-	block, _ := pem.Decode([]byte(rootCA))
-	rootCA, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("parsing root CA: %w", err)
-	}
-
+func New() *TrustedServicesClient {
 	return &TrustedServicesClient{
 		api: &pcsAPIClient{
-			rootCA: rootCA,
+			rootCA: crypto.MustParsePEMCertificate([]byte(rootCA)),
 			client: http.DefaultClient,
 		},
-	}, nil
+	}
 }
 
 // GetPCKCRL retrieves the PCK CRL chain and PCK CA cert from Intel's PCS.

--- a/verification/verification.go
+++ b/verification/verification.go
@@ -46,12 +46,8 @@ type TDXVerifier struct {
 }
 
 // New creates a new TDXVerifier.
-func New() (*TDXVerifier, error) {
-	pcsClient, err := pcs.New()
-	if err != nil {
-		return nil, err
-	}
-	return &TDXVerifier{pcsClient: pcsClient}, nil
+func New() *TDXVerifier {
+	return &TDXVerifier{pcsClient: pcs.New()}
 }
 
 // VerifyQuote verifies a TDX quote.


### PR DESCRIPTION
As title says.
Makes some things simpler in the integration