### PR TITLE
Fix conditional to not return without error on no matching TCB level

### DIFF
--- a/verification/verification.go
+++ b/verification/verification.go
@@ -338,8 +338,9 @@ func (v *TDXVerifier) getMatchingTCBLevel(tcbInfo types.TCBInfo, pckExtensions t
 				if isTCBHigherOrEqual(tcb.TCB.TDXTCBComponents, pckExtensions.TCB.TCBSVN) {
 					return tcb, nil
 				}
+			} else {
+				return tcb, nil
 			}
-			return tcb, nil
 		}
 	}
 


### PR DESCRIPTION
Our check was always returning a TCB level if the SGX components were matching, even if the relevant TDX components were not.

This error is technically caught later on, because returning a non matching TCB level here will later result in validation errors when checking the TCB.

See [the Intel reference code](https://github.com/intel/SGX-TDX-DCAP-QuoteVerificationLibrary/blob/16b7291a7a86e486fdfcf1dfb4be885c0cc00b4e/Src/AttestationLibrary/src/Verifiers/QuoteVerifier.cpp#L102-L122).